### PR TITLE
apt-get update before installing curl

### DIFF
--- a/packagecloud.sh
+++ b/packagecloud.sh
@@ -20,6 +20,7 @@ curl_check ()
     echo "Detected curl..."
   else
     echo "Installing curl..."
+    apt-get update &> /dev/null
     apt-get install -q -y curl
   fi
 }


### PR DESCRIPTION
If a system has cleaned the apt cache before running, this will fail later on with `script.deb.sh: line 115: curl: command not found`.  Fixed by adding an update just before the install of curl.